### PR TITLE
Introduce debug mode

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 - `common.find_closest` now takes `end_lineno` and `end_col_offset` into account. It also ensures there is at least one target node.
+- Added `debug_mode` setting to `refactor.context.Configuration`
+- Added a command-line flag (`-d`/`--enable-debug-mode`) to the default CLI runner to change session's configuration.
+- When some unparsable source code is generated, the contents can be now seen if the debug mode is enabled.
 
 ## 0.4.4
 

--- a/refactor/context.py
+++ b/refactor/context.py
@@ -31,9 +31,11 @@ class Configuration:
     """Configuration settings for refactor.
 
     unparser: precise, fast, or a `BaseUnparser` subclass.
+    debug_mode: whether to output more debug information.
     """
 
     unparser: Union[str, Type[BaseUnparser]] = "precise"
+    debug_mode: bool = False
 
 
 class Dependable(Protocol):

--- a/refactor/core.py
+++ b/refactor/core.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import copy
+import tempfile
 import tokenize
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -178,7 +179,15 @@ class Session:
         if not changed:
             return source, changed
 
-        raise ValueError("Generated source is unparsable") from exc
+        error_message = "Generated source is unparsable."
+
+        if self.config.debug_mode:
+            fd, file_name = tempfile.mkstemp(prefix="refactor", text=True)
+            with open(fd, "w") as stream:
+                stream.write(source)
+            error_message += f"\nSee {file_name} for the generated source."
+
+        raise ValueError(error_message) from exc
 
     def run(self, source: str, *, file: Optional[Path] = None) -> str:
         """Refactor the given string with the rules bound to

--- a/refactor/core.py
+++ b/refactor/core.py
@@ -150,10 +150,7 @@ class Session:
         try:
             tree = ast.parse(source)
         except SyntaxError as exc:
-            if _changed is False:
-                return source, _changed
-            else:
-                raise ValueError("Generated source is unparsable") from exc
+            return self._delegate_syntax_errors(source, _changed, exc)
 
         _known_sources |= {source}
         rules = self._initialize_rules(tree, source, file)
@@ -174,6 +171,14 @@ class Session:
                             )
 
         return source, _changed
+
+    def _delegate_syntax_errors(
+        self, source: str, changed: bool, exc: SyntaxError
+    ) -> Tuple[str, bool]:
+        if not changed:
+            return source, changed
+
+        raise ValueError("Generated source is unparsable") from exc
 
     def run(self, source: str, *, file: Optional[Path] = None) -> str:
         """Refactor the given string with the rules bound to

--- a/refactor/runner.py
+++ b/refactor/runner.py
@@ -64,9 +64,8 @@ def run_files(
     files: Iterable[Path],
     apply: bool = False,
     workers: Any = _DEFAULT_WORKERS,
-    debug_mode: bool = False,
 ) -> int:
-    workers = _determine_workers(workers, debug_mode)
+    workers = _determine_workers(workers, session.config.debug_mode)
 
     executor: ContextManager[Any]
     if workers == 1:
@@ -108,6 +107,7 @@ def unbound_main(session: Session, argv: Optional[List[str]] = None) -> int:
     )
 
     options = parser.parse_args()
+    session.config.debug_mode = options.enable_debug_mode
     files = chain.from_iterable(
         expand_paths(source_dest) for source_dest in options.src
     )
@@ -116,7 +116,6 @@ def unbound_main(session: Session, argv: Optional[List[str]] = None) -> int:
         files,
         apply=options.apply,
         workers=options.workers,
-        debug_mode=options.enable_debug_mode,
     )
 
 


### PR DESCRIPTION
- Adds `debug_mode` setting to `refactor.context.Configuration`
- Adds a command-line flag (`-d`/`--enable-debug-mode`) to the default CLI runner
- When `debug_mode` is enabled, all 'unparsable source code' errors also include a file where the actual code is available (for debugging purposes).