### PR TITLE
fix: preserve encoding when operating directly at the source level

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.6.0
+
+### Other Changes
+- Encoding is now preserved when using the `refactor.Session.run_file` API (which means if you use the `refactor.Change.apply_diff` or using the `-a` flag in the CLI, the generated source code will be encoded
+with the original encoding before getting written to the file.)
+- Offset tracking has been changed to be at the encoded byte stream level (mirroring CPython behavior here). This fixes some unicode related problems (with actions like `refactor.actions.Replace`).
+
 ## 0.5.0
 
 ### Major

--- a/refactor/common.py
+++ b/refactor/common.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import ast
 import copy
 from collections import deque
+from dataclasses import dataclass
 from functools import cache, singledispatch, wraps
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -25,6 +27,22 @@ if TYPE_CHECKING:
 T = TypeVar("T")
 C = TypeVar("C")
 PositionType = Tuple[int, int, int, int]
+
+
+@dataclass
+class _FileInfo:
+    """Represents information regarding the source code (the
+    file it was read from, the encoding, etc.)"""
+
+    path: Optional[Path] = None
+    encoding: Optional[str] = None
+
+    def get_encoding(self) -> str:
+        """Return the encoding for this file (if it doesn't exist,
+        it returns the default encoding -- utf8)."""
+        from refactor.ast import DEFAULT_ENCODING
+
+        return self.encoding or DEFAULT_ENCODING
 
 
 def clone(node: T) -> T:

--- a/refactor/context.py
+++ b/refactor/context.py
@@ -75,7 +75,7 @@ class Context:
     source: str
     tree: ast.AST
 
-    file: Optional[Path] = None
+    file_info: common._FileInfo = field(default_factory=common._FileInfo)
     config: Configuration = field(default_factory=Configuration)
     metadata: Dict[str, Representative] = field(default_factory=dict)
 
@@ -152,6 +152,10 @@ class Context:
         new_cls = replace(self, *args, **kwargs)
         new_cls._update_metadata()
         return new_cls
+
+    @property
+    def file(self) -> Optional[Path]:
+        return self.file_info.path
 
 
 @dataclass

--- a/tests/test_change.py
+++ b/tests/test_change.py
@@ -2,13 +2,14 @@ import os
 import textwrap
 from pathlib import Path
 
+from refactor import common
 from refactor.change import Change
 
 
 def test_change_compute_diff(tmp_path):
-    file = Path(tmp_path)
+    file_info = common._FileInfo(path=Path(tmp_path / "test.py"))
     change = Change(
-        file,
+        file_info,
         textwrap.dedent(
             """
         if (
@@ -38,8 +39,8 @@ def test_change_compute_diff(tmp_path):
     )
 
     assert change.compute_diff().splitlines() == [
-        f"--- {os.fspath(file)}",
-        f"+++ {os.fspath(file)}",
+        f"--- {os.fspath(file_info.path)}",
+        f"+++ {os.fspath(file_info.path)}",
         "@@ -1,8 +1,8 @@",
         " ",
         " if (",

--- a/tests/test_complete_rules.py
+++ b/tests/test_complete_rules.py
@@ -15,6 +15,7 @@ from refactor.actions import (
     LazyReplace,
     Replace,
 )
+from refactor.ast import DEFAULT_ENCODING
 from refactor.context import Representative, Scope, ScopeType
 
 
@@ -781,10 +782,12 @@ def test_complete_rules(rule, tmp_path):
     assert session.run(source_code) == textwrap.dedent(rule.EXPECTED_SOURCE)
 
     src_file_path = Path(tmp_path / rule.__name__.lower()).with_suffix(".py")
-    src_file_path.write_text(source_code)
+    src_file_path.write_text(source_code, encoding=DEFAULT_ENCODING)
 
     change = session.run_file(src_file_path)
     assert change is not None
 
     change.apply_diff()
-    assert src_file_path.read_text() == textwrap.dedent(rule.EXPECTED_SOURCE)
+    assert src_file_path.read_text(
+        encoding=DEFAULT_ENCODING
+    ) == textwrap.dedent(rule.EXPECTED_SOURCE)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ from refactor.context import Configuration, Context, Representative
 from refactor.core import Rule, Session
 
 fake_ctx = Context(source="<test>", tree=ast.AST())
+test_file = common._FileInfo()
 
 
 @pytest.mark.parametrize(
@@ -205,7 +206,10 @@ class RecursiveRule(Rule):
 def test_session_run_deterministic():
     session = Session([RecursiveRule])
 
-    refactored_source, changed = session._run("2 + 2 + 3 + 4")
+    # Using _run here to see the 'changed' flag in action.
+    refactored_source, changed = session._run(
+        "2 + 2 + 3 + 4", file_info=test_file
+    )
     assert not changed
     assert refactored_source == "2 + 2 + 3 + 4"
 


### PR DESCRIPTION
Fixes #61