### PR TITLE
(fix) Workaround for duplicate decorators in def -> async def

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ myst_parser==0.15.1
 furo==2022.06.21
 sphinx-design
 sphinx-hoverxref
+pytest

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -137,6 +137,24 @@ def test_get_positions():
     assert position_for(right_node) == (3, 23, 3, 25)
 
 
+def test_get_positions_with_decorator():
+    source = textwrap.dedent(
+        """\
+    @deco0
+    @deco1(arg0,
+           arg1)
+    def func():
+        if a > 5:
+            return 5 + 3 + 25
+        elif b > 10:
+            return 1 + 3 + 5 + 7
+    """
+    )
+    tree = ast.parse(source)
+    right_node = tree.body[0].body[0].body[0].value.right
+    assert position_for(right_node) == (6, 23, 6, 25)
+
+
 def test_singleton():
     from dataclasses import dataclass
 

--- a/tests/test_complete_rules.py
+++ b/tests/test_complete_rules.py
@@ -397,65 +397,6 @@ class OnlyKeywordArgumentDefaultNotSetCheckRule(Rule):
         return Replace(node, target)
 
 
-class OnlyKeywordArgumentDefaultNotSetCheckRule(Rule):
-    context_providers = (context.Scope,)
-
-    INPUT_SOURCE = """
-        class Klass:
-            def method(self, *, a):
-                print()
-
-            lambda self, *, a: print
-
-        """
-
-    EXPECTED_SOURCE = """
-        class Klass:
-            def method(self, *, a=None):
-                print()
-
-            lambda self, *, a=None: print
-
-        """
-
-    def match(self, node: ast.AST) -> BaseAction | None:
-        assert isinstance(node, (ast.FunctionDef, ast.Lambda))
-        assert any(kw_default is None for kw_default in node.args.kw_defaults)
-
-        if isinstance(node, ast.Lambda) and not (
-            isinstance(node.body, ast.Name) and isinstance(node.body.ctx, ast.Load)
-        ):
-            scope = self.context["scope"].resolve(node.body)
-            scope.definitions.get(node.body.id, [])
-
-        elif isinstance(node, ast.FunctionDef):
-            for stmt in node.body:
-                for identifier in ast.walk(stmt):
-                    if not (
-                        isinstance(identifier, ast.Name)
-                        and isinstance(identifier.ctx, ast.Load)
-                    ):
-                        continue
-
-                    scope = self.context["scope"].resolve(identifier)
-                    while not scope.definitions.get(identifier.id, []):
-                        scope = scope.parent
-                        if scope is None:
-                            break
-
-        kw_defaults = []
-        for kw_default in node.args.kw_defaults:
-            if kw_default is None:
-                kw_defaults.append(ast.Constant(value=None))
-            else:
-                kw_defaults.append(kw_default)
-
-        target = deepcopy(node)
-        target.args.kw_defaults = kw_defaults
-
-        return Replace(node, target)
-
-
 class InternalizeFunctions(Rule):
     INPUT_SOURCE = """
         __all__ = ["regular"]
@@ -1045,7 +986,6 @@ class AtomicTryBlock(Rule):
 @pytest.mark.parametrize(
     "rule",
     [
-        MakeFunctionAsyncWithDecorators,
         ReplaceNexts,
         ReplacePlaceholders,
         PropagateConstants,


### PR DESCRIPTION
Related to: https://github.com/isidentical/refactor/issues/55
Observation:
    - When Asyncifing a decorated function, the decorators are duplicated
Understanding:
    - In `apply()` method of`_ReplaceCodeSegmentAction`, the `lines` exclude the decorators (from `position_for()`)
    - Building the `replacement` is based on the `context`, which includes the decorators
    - Replacing the `lines` slice with the `replacement` ends up duplicating the decorators
Proposal:
    - A possible solution is to include the decorators in the `lines` since `_resyntesize()` works with the 
    context that includes the decorators