### PR TITLE
(fix) Proposing to collect empty separation lines with comments

### DIFF
--- a/refactor/ast.py
+++ b/refactor/ast.py
@@ -255,5 +255,57 @@ class PreciseUnparser(BaseUnparser):
                 self.fill()
             self.write(segment)
 
+class PreciseEmptyLinesUnparser(PreciseUnparser):
+    """A more precise version of the default unparser,
+    with various improvements such as comment handling
+    for major statements and child node recovery."""
 
-UNPARSER_BACKENDS = {"fast": BaseUnparser, "precise": PreciseUnparser}
+    @contextmanager
+    def _collect_stmt_comments(self, node: ast.AST) -> Iterator[None]:
+        def _write_if_unseen_comment(
+            line_no: int,
+            line: str,
+            comment_begin: int,
+        ) -> None:
+            if line_no in self._visited_comment_lines:
+                # We have already written this comment as the
+                # end of another node. No need to re-write it.
+                return
+
+            self.fill()
+            self.write(line[comment_begin:])
+            self._visited_comment_lines.add(line_no)
+
+        assert self.source is not None
+        lines = self.source.splitlines()
+        node_start, node_end = node.lineno - 1, cast(int, node.end_lineno)
+
+        # Collect comments in the reverse order, so we can properly
+        # identify the end of the current comment block.
+        preceding_comments = []
+        for offset, line in enumerate(reversed(lines[:node_start])):
+            comment_begin = line.find("#")
+            if (line or line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
+                break
+
+            preceding_comments.append((node_start - offset, line, node.col_offset))
+
+        for comment_info in reversed(preceding_comments):
+            _write_if_unseen_comment(*comment_info)
+
+        yield
+
+        for offset, line in enumerate(lines[node_end:], 1):
+            comment_begin = line.find("#")
+            if (line or line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
+                break
+
+            _write_if_unseen_comment(
+                line_no=node_end + offset,
+                line=line,
+                comment_begin=node.col_offset,
+            )
+
+
+
+UNPARSER_BACKENDS = {"fast": BaseUnparser, "precise": PreciseUnparser, "precise_with_empty_lines": PreciseEmptyLinesUnparser}

--- a/refactor/ast.py
+++ b/refactor/ast.py
@@ -285,7 +285,7 @@ class PreciseEmptyLinesUnparser(PreciseUnparser):
         preceding_comments = []
         for offset, line in enumerate(reversed(lines[:node_start])):
             comment_begin = line.find("#")
-            if (line or line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
+            if (line and not line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
                 break
 
             preceding_comments.append((node_start - offset, line, node.col_offset))
@@ -297,7 +297,7 @@ class PreciseEmptyLinesUnparser(PreciseUnparser):
 
         for offset, line in enumerate(lines[node_end:], 1):
             comment_begin = line.find("#")
-            if (line or line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
+            if (line and not line.isspace()) and (comment_begin == -1 or comment_begin != node.col_offset):
                 break
 
             _write_if_unseen_comment(

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -241,48 +241,107 @@ def test_precise_unparser_comments():
     base = PreciseUnparser(source=source)
     assert base.unparse(tree) + "\n" == expected_src
 
-def test_precise_unparser_comments_empty_lines():
+
+
+def test_precise_empty_lines_unparser():
     source = textwrap.dedent(
         """\
-    def foo():
-    # unindented comment
-        # indented but not connected comment
-
-        # a
-        # a1
-        print()
-        # a2
-        print()
-        # b
-
-        # b2
-        print(
-            c # e
-        )
-        # c
-        print(d)
-        # final comment
+    def func():
+        if something:
+            print(
+                call(.1),
+                maybe+something_else,
+                maybe / other,
+                thing   . a
+            )
     """
     )
 
     expected_src = textwrap.dedent(
         """\
-    def foo():
-        # indented but not connected comment
-        
-        # a
-        # a1
-        print()
-        # a2
-        print()
-        # b
-        
-        # b2
-        print(
-            c # e
-        )
-        # c
+    def func():
+        if something:
+            print(call(.1), maybe+something_else, maybe / other, thing   . a, 3)
     """
+    )
+
+    tree = ast.parse(source)
+    tree.body[0].body[0].body[0].value.args.append(ast.Constant(3))
+
+    base = PreciseEmptyLinesUnparser(source=source)
+    assert base.unparse(tree) + "\n" == expected_src
+
+
+def test_precise_empty_lines_unparser_indented_literals():
+    source = textwrap.dedent(
+        """\
+    def func():
+        if something:
+            print(
+                "bleh"
+                "zoom"
+            )
+    """
+    )
+
+    expected_src = textwrap.dedent(
+        """\
+    def func():
+        if something:
+            print("bleh"
+                "zoom", 3)
+    """
+    )
+
+    tree = ast.parse(source)
+    tree.body[0].body[0].body[0].value.args.append(ast.Constant(3))
+
+    base = PreciseEmptyLinesUnparser(source=source)
+    assert base.unparse(tree) + "\n" == expected_src
+
+def test_precise_empty_lines_unparser_comments():
+    #source = textwrap.dedent(
+    source = (
+        """\
+def foo():
+# unindented comment
+    # indented but not connected comment
+    
+    # a
+    # a1
+    print()
+    # a2
+    print()
+    # b
+    
+    # b2
+    print(
+        c # e
+    )
+    # c
+    print(d)
+    # final comment
+"""
+    )
+
+    expected_src = (
+        """\
+def foo():
+    # indented but not connected comment
+    
+    # a
+    # a1
+    print()
+    # a2
+    print()
+    # b
+    
+    # b2
+    print(
+        c # e
+    )
+    # c
+"""
     )
 
     tree = ast.parse(source)


### PR DESCRIPTION
This is not fully tested, in particular the added test fails because the \:
```
    expected_src = textwrap.dedent(
        """\
    def foo():
        # indented but not connected comment
        
```
cannot hold a line of spaces, but the modification automatically produces them, so the test fails with no possibility to make it pass (maybe this is a `dedent` particularity?