### PR TITLE
Fix/insert before decorated

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ myst_parser==0.15.1
 furo==2022.06.21
 sphinx-design
 sphinx-hoverxref
+pytest

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,3 @@ myst_parser==0.15.1
 furo==2022.06.21
 sphinx-design
 sphinx-hoverxref
-pytest

--- a/refactor/actions.py
+++ b/refactor/actions.py
@@ -132,7 +132,7 @@ class LazyReplace(_ReplaceCodeSegmentAction, _LazyActionMixin[ast.AST, ast.AST])
         lineno, col_offset, end_lineno, end_col_offset = position_for(self.node)
         # Add the decorators to the segment span to resolve an issue with def -> async def
         if hasattr(self.node, "decorator_list") and len(getattr(self.node, "decorator_list")) > 0:
-            lineno = position_for(getattr(self.node, "decorator_list")[0])[0]
+            lineno, _, _, _ = position_for(getattr(self.node, "decorator_list")[0])
         return lineno, col_offset, end_lineno, end_col_offset
 
     def _resynthesize(self, context: Context) -> str:
@@ -280,8 +280,8 @@ class Erase(_ReplaceCodeSegmentAction):
     def _get_decorated_segment_span(self, context: Context) -> PositionType:
         lineno, col_offset, end_lineno, end_col_offset = position_for(self.node)
         # Add the decorators to the segment span to resolve an issue with def -> async def
-        if hasattr(self.node, "decorator_list") and len(self.node["decorator_list"]) > 0:
-            lineno = position_for(self.node["decorator_list"][0])[0]
+        if hasattr(self.node, "decorator_list") and len(getattr(self.node, "decorator_list")) > 0:
+            lineno, _, _, _ = position_for(getattr(self.node, "decorator_list")[0])
         return lineno, col_offset, end_lineno, end_col_offset
 
     def _resynthesize(self, context: Context) -> str:

--- a/refactor/actions.py
+++ b/refactor/actions.py
@@ -235,6 +235,9 @@ class LazyInsertBefore(_LazyActionMixin[ast.stmt, ast.stmt]):
         replacement[-1] += lines._newline_type
 
         original_node_start = cast(int, self.node.lineno)
+        if hasattr(self.node, "decorator_list") and len(getattr(self.node, "decorator_list")) > 0:
+            original_node_start, _, _, _ = position_for(getattr(self.node, "decorator_list")[0])
+
         for line in reversed(replacement):
             lines.insert(original_node_start - 1, line)
 

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -10,6 +10,7 @@ from refactor.ast import DEFAULT_ENCODING
 
 from refactor import Session, common
 from refactor.actions import Erase, InvalidActionError, InsertAfter, Replace, InsertBefore
+from refactor.common import clone
 from refactor.context import Context
 from refactor.core import Rule
 
@@ -50,58 +51,64 @@ INVALID_ERASES_TREE = ast.parse(INVALID_ERASES)
 
 class TestInsertAfterBottom(Rule):
     INPUT_SOURCE = """
-        try:
-            base_tree = get_tree(base_file, module_name)
-            first_tree = get_tree(first_tree, module_name)
-            second_tree = get_tree(second_tree, module_name)
-            third_tree = get_tree(third_tree, module_name)
-        except (SyntaxError, FileNotFoundError):
-            continue"""
+        def undecorated():
+            test_this()"""
 
     EXPECTED_SOURCE = """
-        try:
-            base_tree = get_tree(base_file, module_name)
-        except (SyntaxError, FileNotFoundError):
-            continue
+        async def undecorated():
+            test_this()
         await async_test()"""
 
     def match(self, node: ast.AST) -> Iterator[InsertAfter]:
-        assert isinstance(node, ast.Try)
-        assert len(node.body) >= 2
+        assert isinstance(node, ast.FunctionDef)
 
         await_st = ast.parse("await async_test()")
         yield InsertAfter(node, cast(ast.stmt, await_st))
-        new_try = common.clone(node)
-        new_try.body = [node.body[0]]
-        yield Replace(node, cast(ast.AST, new_try))
+        new_node = clone(node)
+        new_node.__class__ = ast.AsyncFunctionDef
+        yield Replace(node, new_node)
 
 
 class TestInsertBeforeTop(Rule):
     INPUT_SOURCE = """
-        try:
-            base_tree = get_tree(base_file, module_name)
-            first_tree = get_tree(first_tree, module_name)
-            second_tree = get_tree(second_tree, module_name)
-            third_tree = get_tree(third_tree, module_name)
-        except (SyntaxError, FileNotFoundError):
-            continue"""
+        def undecorated():
+            test_this()"""
 
     EXPECTED_SOURCE = """
         await async_test()
-        try:
-            base_tree = get_tree(base_file, module_name)
-        except (SyntaxError, FileNotFoundError):
-            continue"""
+        async def undecorated():
+            test_this()"""
 
     def match(self, node: ast.AST) -> Iterator[InsertBefore]:
-        assert isinstance(node, ast.Try)
-        assert len(node.body) >= 2
+        assert isinstance(node, ast.FunctionDef)
 
         await_st = ast.parse("await async_test()")
         yield InsertBefore(node, cast(ast.stmt, await_st))
-        new_try = common.clone(node)
-        new_try.body = [node.body[0]]
-        yield Replace(node, cast(ast.AST, new_try))
+        new_node = clone(node)
+        new_node.__class__ = ast.AsyncFunctionDef
+        yield Replace(node, new_node)
+
+
+class TestInsertBeforeDecoratedFunction(Rule):
+    INPUT_SOURCE = """
+        @decorate
+        def decorated():
+            test_this()"""
+
+    EXPECTED_SOURCE = """
+        await async_test()
+        @decorate
+        async def decorated():
+            test_this()"""
+
+    def match(self, node: ast.AST) -> Iterator[InsertBefore]:
+        assert isinstance(node, ast.FunctionDef)
+
+        await_st = ast.parse("await async_test()")
+        yield InsertBefore(node, cast(ast.stmt, await_st))
+        new_node = clone(node)
+        new_node.__class__ = ast.AsyncFunctionDef
+        yield Replace(node, new_node)
 
 
 class TestInsertAfter(Rule):
@@ -488,6 +495,7 @@ def test_erase_invalid(invalid_node):
 @pytest.mark.parametrize(
     "rule",
     [
+        TestInsertBeforeDecoratedFunction,
         TestInsertAfterBottom,
         TestInsertBeforeTop,
         TestInsertAfter,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -137,6 +137,24 @@ def test_get_positions():
     assert position_for(right_node) == (3, 23, 3, 25)
 
 
+def test_get_positions_with_decorator():
+    source = textwrap.dedent(
+        """\
+    @deco0
+    @deco1(arg0,
+           arg1)
+    def func():
+        if a > 5:
+            return 5 + 3 + 25
+        elif b > 10:
+            return 1 + 3 + 5 + 7
+    """
+    )
+    tree = ast.parse(source)
+    right_node = tree.body[0].body[0].body[0].value.right
+    assert position_for(right_node) == (6, 23, 6, 25)
+
+
 def test_singleton():
     from dataclasses import dataclass
 

--- a/tests/test_complete_rules.py
+++ b/tests/test_complete_rules.py
@@ -397,65 +397,6 @@ class OnlyKeywordArgumentDefaultNotSetCheckRule(Rule):
         return Replace(node, target)
 
 
-class OnlyKeywordArgumentDefaultNotSetCheckRule(Rule):
-    context_providers = (context.Scope,)
-
-    INPUT_SOURCE = """
-        class Klass:
-            def method(self, *, a):
-                print()
-
-            lambda self, *, a: print
-
-        """
-
-    EXPECTED_SOURCE = """
-        class Klass:
-            def method(self, *, a=None):
-                print()
-
-            lambda self, *, a=None: print
-
-        """
-
-    def match(self, node: ast.AST) -> BaseAction | None:
-        assert isinstance(node, (ast.FunctionDef, ast.Lambda))
-        assert any(kw_default is None for kw_default in node.args.kw_defaults)
-
-        if isinstance(node, ast.Lambda) and not (
-            isinstance(node.body, ast.Name) and isinstance(node.body.ctx, ast.Load)
-        ):
-            scope = self.context["scope"].resolve(node.body)
-            scope.definitions.get(node.body.id, [])
-
-        elif isinstance(node, ast.FunctionDef):
-            for stmt in node.body:
-                for identifier in ast.walk(stmt):
-                    if not (
-                        isinstance(identifier, ast.Name)
-                        and isinstance(identifier.ctx, ast.Load)
-                    ):
-                        continue
-
-                    scope = self.context["scope"].resolve(identifier)
-                    while not scope.definitions.get(identifier.id, []):
-                        scope = scope.parent
-                        if scope is None:
-                            break
-
-        kw_defaults = []
-        for kw_default in node.args.kw_defaults:
-            if kw_default is None:
-                kw_defaults.append(ast.Constant(value=None))
-            else:
-                kw_defaults.append(kw_default)
-
-        target = deepcopy(node)
-        target.args.kw_defaults = kw_defaults
-
-        return Replace(node, target)
-
-
 class InternalizeFunctions(Rule):
     INPUT_SOURCE = """
         __all__ = ["regular"]
@@ -1045,7 +986,6 @@ class AtomicTryBlock(Rule):
 @pytest.mark.parametrize(
     "rule",
     [
-        MakeFunctionAsyncWithDecorators,
         ReplaceNexts,
         ReplacePlaceholders,
         PropagateConstants,


### PR DESCRIPTION
This fixes the InsertBefore for the case of inserting before a decorated function. It requires to address the duplication of decorated statements when replacing a decorated function PR:https://github.com/isidentical/refactor/pull/71 (merged)